### PR TITLE
SGS 186

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,12 @@ if (APPLE)
     list(REMOVE_ITEM LIBS rt)
 endif (APPLE)
 
+if (CMAKE_SYSTEM_NAME MATCHES "Linux")
+if (CMAKE_SYSTEM_PROCESSOR MATCHES "^i[3-9]86$")
+    add_definitions(${APR_CONFIG_EXECUTABLE} ${APR_FLAGS})
+endif (CMAKE_SYSTEM_PROCESSOR MATCHES "^i[3-9]86$")
+endif (CMAKE_SYSTEM_NAME MATCHES "Linux")
+
 # Try finding optional dependencies
 find_package(Phoebus)
 find_package(Unisc)

--- a/cmake/FindAPR.cmake
+++ b/cmake/FindAPR.cmake
@@ -8,6 +8,7 @@
 #  APR_FOUND and APRUTIL_FOUND, If false, do not try to use APR.
 # also defined, but not for general use are
 #  APR_LIBRARY and APRUTIL_LIBRARY, where to find the APR library.
+#  APR_FLAGS, the flags to use to compile.
 
 # APR first.
 
@@ -48,6 +49,39 @@ IF (APR_FOUND)
    IF (NOT APR_FIND_QUIETLY)
       MESSAGE(STATUS "Found APR: ${APR_LIBRARIES} ${APR_INCLUDE_DIR}")
    ENDIF (NOT APR_FIND_QUIETLY)
+   
+   FIND_PROGRAM(APR_CONFIG_EXECUTABLE
+      apr-1-config
+      /usr/local/bin
+      /usr/bin
+   )
+   MARK_AS_ADVANCED(APR_CONFIG_EXECUTABLE)
+   MACRO(_APR_INVOKE _VARNAME _REGEXP)
+      EXECUTE_PROCESS(
+          COMMAND ${APR_CONFIG_EXECUTABLE} ${ARGN}
+          OUTPUT_VARIABLE _APR_OUTPUT
+          RESULT_VARIABLE _APR_FAILED     
+      )
+   
+      IF (_APR_FAILED)
+         MESSAGE(FATAL_ERROR "${APR_CONFIG_EXECUTABLE} ${ARGN} failed")
+      ELSE (_APR_FAILED)
+         STRING(REGEX REPLACE "[\r\n]" "" _APR_OUTPUT "${_APR_OUTPUT}")
+         STRING(REGEX REPLACE " +$"    "" _APR_OUTPUT "${_APR_OUTPUT}")
+
+         IF (NOT ${_REGEXP} STREQUAL "")
+            STRING(REGEX REPLACE "${_REGEXP}" " " _APR_OUTPUT "${_APR_OUTPUT}")
+         ENDIF (NOT ${_REGEXP} STREQUAL "")
+         
+         IF (NOT ${_VARNAME} STREQUAL "APR_FLAGS")
+            SEPARATE_ARGUMENTS(_APR_OUTPUT)
+         ENDIF (NOT ${_VARNAME} STREQUAL "APR_FLAGS")
+
+         SET(${_VARNAME} "${_APR_OUTPUT}")
+      ENDIF (_APR_FAILED)
+   ENDMACRO(_APR_INVOKE)
+
+   _APR_INVOKE(APR_FLAGS "" --cppflags --cflags)
 ELSE (APR_FOUND)
    IF (APR_FIND_REQUIRED)
       MESSAGE(FATAL_ERROR "Could not find APR library")
@@ -55,8 +89,8 @@ ELSE (APR_FOUND)
 ENDIF (APR_FOUND)
 
 # Deprecated declarations.
-SET (NATIVE_APR_INCLUDE_PATH ${APR_INCLUDE_DIR} )
-GET_FILENAME_COMPONENT (NATIVE_APR_LIB_PATH ${APR_LIBRARY} PATH)
+SET(NATIVE_APR_INCLUDE_PATH ${APR_INCLUDE_DIR} )
+GET_FILENAME_COMPONENT(NATIVE_APR_LIB_PATH ${APR_LIBRARY} PATH)
 
 MARK_AS_ADVANCED(
   APR_LIBRARY


### PR DESCRIPTION
This fixes the build failure of ibp_server with 32-bit architecture.

With Centos - 6.7 32-bit ISO image,
ibp_server fails to compile.
/usr/include/apr-1/apr.h:285:28: error: expected '=', ',', ';', 'asm' or '_attribute_' before 'apr_off_t'
This is due to the fact that not all options are passed to the compiler. 
pass the following: `/usr/local/bin/apr-1-config -cppflags -cflags` to compiler