### PR TITLE
Fix blipp_config_file path error.

### DIFF
--- a/misc/ibp_configure.py
+++ b/misc/ibp_configure.py
@@ -286,7 +286,11 @@ class Configuration():
         return path.join(self.ibp_root, "etc/ibp.cfg")
 
     def blipp_config_file(self):
-        return path.join(self.ibp_root, "etc/periscope/blipp_dlt.json")
+        # check that etc/periscope exists
+        filename = "/etc/periscope/blipp_dlt.json"
+        if not os.path.exists(os.path.dirname(filename)):
+            os.makedirs(os.path.dirname(filename))
+        return path.join(self.ibp_root, filename)
 
     def ibp_interface_monitor(self):
         return path.join(self.ibp_root, "bin/ibp_interface_monitor.py") + " -l -d"


### PR DESCRIPTION
This fixes the blipp error when running ibp_configure.py:

[INFO]   Start BLiPP using systemctl or service
Traceback (most recent call last):
  File "/bin/ibp_configure.py", line 667, in <module>
    main()
  File "/bin/ibp_configure.py", line 652, in main
    blipp_config = cfg.generate_blipp_config(args)
  File "/bin/ibp_configure.py", line 520, in generate_blipp_config
    self.save_and_write(self.blipp_config_file(), blipp_config)
  File "/bin/ibp_configure.py", line 426, in save_and_write
    with open(fname, 'w') as f:
IOError: [Errno 2] No such file or directory: '/etc/periscope/blipp_dlt.json'

The path was changed a few days back. So, Probably need to create the /etc/periscope folder.
https://github.com/datalogistics/ibp_server/commit/1d05d6e386a0cb15525c4ec1c4e49256b6d3636d#diff-d8e2c96f9eefcbeeedf2b42913e76311