### PR TITLE
Make sure we create the tmp dbenv after daemonizing.

### DIFF
--- a/README
+++ b/README
@@ -66,7 +66,9 @@ IBP configuration options
 [server] options
 -------------------------------
 user=<user>
-  Run the ibp_server as the specified user, default=ibp.
+  Run the ibp_server as the specified user, default=ibp.  This applies only
+  when running as a daemon.  If run in the foreground, ibp_server will run
+  as the current user.
 
 group=<group>
   Run the ibp_server as the specified group, default=ibp.

--- a/iniparse.c
+++ b/iniparse.c
@@ -41,8 +41,8 @@ char * _get_line(bfile_t *bfd)
    if (bfd->curr->used == 1) return(bfd->curr->buffer);
 
    comment = fgets(bfd->curr->buffer, BUFMAX, bfd->curr->fd);
-log_printf(15, "_get_line: fgets=%s", comment);
-
+   log_printf(15, "_get_line: fgets=%s", comment);
+ 
    if (comment == NULL) {  //** EOF or error
      fclose(bfd->curr->fd);
      free(bfd->curr);

--- a/misc/ibp_configure.py
+++ b/misc/ibp_configure.py
@@ -95,7 +95,6 @@ type = ibp_server
 endpoint = {unis_endpoint}
 protocol_name= ibp
 registration_interval = 600
-max_duration = {seconds}  
 publicip = {public_ip}
 publicport = {port}
 use_ssl = {use_ssl}
@@ -650,7 +649,6 @@ class Configuration():
         unis_config = UNIS_SAMPLE_CONFIG.format(unis_endpoint=self.unis_endpoint,
                                                 public_ip=self.ibp_host,
                                                 port=self.ibp_port,
-                                                seconds=self.max_duration,
                                                 use_ssl=int(self.unis_use_ssl),
                                                 cert_file=self.unis_cert_file,
                                                 key_file=self.unis_key_file,

--- a/register_unis.c
+++ b/register_unis.c
@@ -56,11 +56,11 @@ void parse_unis_config(inip_file_t *kf)
   config->cacerts = NULL;
   memcpy(&config->loc_info, &location, sizeof(location));
 
-  log_printf(5, "UNIS: %s:%s:%s:%s:%s:%d:%d:%d:%d:%s:%s:%d", config->name,
-	     config->type, config->endpoint, config->protocol_name,
-	     config->iface, config->port, config->do_register,
-	     config->registration_interval, config->refresh_timer,
-	     config->certfile, config->keyfile, config->use_ssl);
+  log_printf(0, "UNIS server   : %s\n", config->endpoint);
+  log_printf(0, "UNIS iface    : %s\n", config->iface);
+  log_printf(0, "UNIS certfile : %s\n", config->certfile);
+  log_printf(0, "UNIS keyfile  : %s\n", config->keyfile);
+  log_printf(0, "UNIS use SSL  : %d\n", config->use_ssl);
 }
 
 //*************************************************************************


### PR DESCRIPTION
Restored the stdout/stderr logging when running as a daemon.
Added some helpful UNIS log statements.